### PR TITLE
Fix typo in dark mode comment

### DIFF
--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -2,7 +2,7 @@ const body = document.body;
 const darkModeToggle = document.getElementById('dark-mode-toggle');
 const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
-// Check if user preference is set, if not check value of body class for light or dark else it means that colorsheme = auto
+// Check if user preference is set, if not check value of body class for light or dark else it means that colorscheme = auto
 if (localStorage.getItem("colorscheme")) {
   setTheme(localStorage.getItem("colorscheme"));
 } else if (body.classList.contains('colorscheme-light') || body.classList.contains('colorscheme-dark')) {


### PR DESCRIPTION
## Summary
- fix colorscheme typo in JS dark mode logic

## Testing
- `hugo` *(fails: type <nil> not supported in Resource transformations)*

------
https://chatgpt.com/codex/tasks/task_e_68786a9ef198832a9c5d902d42a75c4f